### PR TITLE
fixed the enrollment bugs and unenroll

### DIFF
--- a/app/assets/stylesheets/pages/_home.scss
+++ b/app/assets/stylesheets/pages/_home.scss
@@ -3,6 +3,8 @@ h1 {
   font-size: x-large;
   font-weight: bolder;
   color: rgb(100, 100, 100);
+  z-index: 10;
+  position: relative;
 }
 
 h2 {
@@ -40,4 +42,9 @@ body {
 
 .small-text {
   font-size: small;
+}
+
+
+.show-title {
+  margin-top: 80px; /* adjust the value as needed */
 }

--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,6 +1,6 @@
 class CoursesController < ApplicationController
   before_action :set_course, only: [:show, :edit, :update, :destroy]
-  before_action :authenticate_user!, except: [:show, :index]
+  before_action :authenticate_user!, except: [:show, :index, :data, :fullstack]
 
   def index
     @courses = Course.all
@@ -18,6 +18,7 @@ class CoursesController < ApplicationController
 
   def show
     @reviews = @course.reviews
+    @enrolment = @course.enrolments.find_by(user: current_user)
     authorize @course
   end
 
@@ -68,7 +69,7 @@ class CoursesController < ApplicationController
 
   # Code added to cancel enrolments
   def cancel_enrolment
-    @enrolment = current_user.enrolments.find(params[:id])
+    @enrolment = current_user.enrolments.find_by(course_id: params[:course_id], id: params[:id])
     authorize @enrolment
     if @enrolment.destroy
       redirect_to enrolments_path, notice: 'Enrolment was successfully cancelled.'
@@ -76,6 +77,7 @@ class CoursesController < ApplicationController
       redirect_to enrolments_path, alert: 'Enrolment could not be cancelled.'
     end
   end
+
 
   private
 

--- a/app/controllers/enrolments_controller.rb
+++ b/app/controllers/enrolments_controller.rb
@@ -1,7 +1,7 @@
 class EnrolmentsController < ApplicationController
   before_action :set_enrolment, only: [:show, :edit, :update, :destroy]
-  before_action :authorize_enrolment, except: [:create]
-  # before_action :set_course
+
+  before_action :set_course, only: [:new, :create]
 
   def index
     @enrolments = policy_scope(current_user.enrolments)
@@ -13,15 +13,12 @@ class EnrolmentsController < ApplicationController
   end
 
   def new
-    @course = Course.find(params[:course_id])
+    authorize
     @enrolment = @course.enrolments.build
     authorize @enrolment
   end
 
   def create
-    @course = Course.find(params[:id])
-    authorize @course
-
     @enrolment = Enrolment.new(course: @course)
     @enrolment.user = current_user
     authorize @enrolment
@@ -33,13 +30,14 @@ class EnrolmentsController < ApplicationController
     end
   end
 
-
-
   def destroy
-    @enrolment = current_user.enrolments.find(params[:enrolment_id])
+    @enrolment = current_user.enrolments.find(params[:id])
     authorize @enrolment
-    @enrolment.destroy
-    redirect_to enrolments_path, notice: 'Enrolment was successfully destroyed.'
+    if @enrolment.destroy
+      redirect_to enrolments_path, notice: 'Enrolment was successfully cancelled.'
+    else
+      redirect_to enrolments_path, alert: 'Enrolment could not be cancelled.'
+    end
   end
 
   private
@@ -50,10 +48,6 @@ class EnrolmentsController < ApplicationController
 
   def enrolment_params
     params.require(:enrolment).permit(:course_id, :user_id)
-  end
-
-  def authorize_enrolment
-    authorize current_user.enrolments
   end
 
   def set_course

--- a/app/javascript/controllers/hello_controller.js
+++ b/app/javascript/controllers/hello_controller.js
@@ -1,7 +1,15 @@
 import { Controller } from "@hotwired/stimulus"
 
 export default class extends Controller {
+  static targets = ["form"]
+
   connect() {
-    this.element.textContent = "Hello World!"
+    console.log("Hello World!")
+  }
+
+  confirm() {
+    if (confirm("Are you sure you want to unenroll from this course?")) {
+      this.formTarget.submit()
+    }
   }
 }

--- a/app/models/enrolment.rb
+++ b/app/models/enrolment.rb
@@ -1,7 +1,7 @@
 class Enrolment < ApplicationRecord
   belongs_to :user
   belongs_to :course
-  has_many :reviews
+  has_many :reviews, dependent: :destroy
 
   validates :user, presence: true
   validates :course, presence: true

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -17,7 +17,7 @@ class ApplicationPolicy
   end
 
   def create?
-    false
+    user.admin?
   end
 
   def new?
@@ -25,7 +25,7 @@ class ApplicationPolicy
   end
 
   def update?
-    false
+    user.admin?
   end
 
   def edit?

--- a/app/policies/course_policy.rb
+++ b/app/policies/course_policy.rb
@@ -2,7 +2,7 @@ class CoursePolicy < ApplicationPolicy
   class Scope < Scope
     # NOTE: Be explicit about which records you allow access to!
     def resolve
-      user.admin? ? scope.all : scope.where(user: user)
+      scope.all
     end
   end
 
@@ -40,5 +40,9 @@ class CoursePolicy < ApplicationPolicy
 
   def search?
     true
+  end
+
+  def enroll?
+    user && !user.enrolled_in?(record)
   end
 end

--- a/app/policies/enrolment_policy.rb
+++ b/app/policies/enrolment_policy.rb
@@ -1,6 +1,7 @@
 class EnrolmentPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
+      scope.all
     #   if user.admin?
     #     scope.all
     #   else
@@ -36,6 +37,22 @@ class EnrolmentPolicy < ApplicationPolicy
 
   def new?
     create?
+  end
+
+  def data?
+    true
+  end
+
+  def fullstack?
+    true
+  end
+
+  def search?
+    true
+  end
+
+  def enroll?
+    true
   end
 
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,11 +1,12 @@
 class UserPolicy < ApplicationPolicy
   class Scope < Scope
     def resolve
-      if user.admin?
-        scope.all
-      else
-        scope.where(id: user.id)
-      end
+      scope.all
+      # if user.admin?
+      #   scope.all
+      # else
+      #   scope.where(id: user.id)
+      # end
     end
   end
 

--- a/app/views/courses/show.html.erb
+++ b/app/views/courses/show.html.erb
@@ -1,6 +1,6 @@
 <div class="container mt-5">
   <div class="row">
-    <h1 class="mt-2"><%= @course.title %></h1>
+    <h1 class="mt-2 show-title"><%= @course.title %></h1>
 
     <div class="col-7">
       <div class="card">
@@ -10,45 +10,31 @@
           <p class="card-text small-text">Category: <%= @course.category %></p>
           <p class="card-text small-text">Syllabus: <%= @course.syllabus%></p>
           <% if @course.session_start.present? %>
-            <p>Next session start: <%= parse_date(@course.session_start) %></p>
+            <p class="card-text">Next session start: <%= Date.parse(@course.session_start.to_s).strftime("%B %d, %Y") %></p>
           <% end %>
           <% if @course.session_end.present? %>
-            <p>Next session end: <%= parse_date(@course.session_end) %></p>
+            <p class="card-text">Next session end: <%= Date.parse(@course.session_end.to_s).strftime("%B %d, %Y") %></p>
           <% end %>
-
-          <%# Helper method to parse date %>
-          <% def parse_date(date) %>
-            <% begin %>
-              <%= Date.parse(date.to_s).strftime("%B %d, %Y") %>
-            <% rescue ArgumentError %>
-              Invalid date
-            <% end %>
-          <% end %>
-
           <div>
-            <% if user_signed_in? && current_user != @course.user %>
-              <% if current_user.enrolled_in?(@course) %>
-                <%= link_to "Unenroll", enrol_path(@course), method: :delete, data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to unenroll from this course?" }, class: "btn-unenroll" %>
+            <% if !user_signed_in? %>
+                <%= link_to "Enroll", new_user_session_path, class: "btn-enrol" %>
+              <% elsif current_user == @course.user %>
+                <% if policy(@course).edit? %>
+                  <%= link_to edit_course_path(@course) do %>
+                    <i class="fas fa-edit me-3 "></i>
+                  <% end %>
+                <% end %>
+                <% if policy(@course).destroy? %>
+                  <%= link_to @course, method: :delete, data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to delete this course?" } do %>
+                    <i class="fas fa-trash-alt"></i>
+                  <% end %>
+                <% end %>
+              <% elsif current_user.enrolled_in?(@course) %>
+                <%= button_to "Unenroll", enrolment_path(id: @enrolment.id, course_id: @course.id), method: :delete, data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to unenroll from this course?" }, class: "btn btn-danger" %>
               <% else %>
                 <%= link_to "Enroll", enrol_new_course_path(@course), class: "btn-enrol" %>
               <% end %>
-            <% end %>
-          </div>
-
-          <% if user_signed_in? && @course.user == current_user %>
-            <div class="d-flex">
-              <% if policy(@course).edit? %>
-                <%= link_to edit_course_path(@course) do %>
-                  <i class="fas fa-edit me-3 "></i>
-                <% end %>
-              <% end %>
-              <% if policy(@course).destroy? %>
-                <%= link_to @course, method: :delete, data: { turbo_method: :delete, turbo_confirm: "Are you sure you want to delete this course?" } do %>
-                  <i class="fas fa-trash-alt"></i>
-                <% end %>
-              <% end %>
             </div>
-          <% end %>
         </div>
       </div>
     </div>
@@ -70,4 +56,4 @@
         </div>
       </div>
     </div>
-  </div
+  </div>

--- a/app/views/enrolments/index.html.erb
+++ b/app/views/enrolments/index.html.erb
@@ -9,9 +9,6 @@
             <p class="card-text"><%= enrolment.course.description %></p>
             <%= link_to "Course Content", course_path(enrolment.course), class: "btn btn-primary btn-enrol" %>
             <%= link_to "Review This Course", new_enrolment_review_path(enrolment), class: "btn btn-secondary btn-view" %>
-            <%= form_with url: remove_enrolment_path(enrolment.id), method: :delete do |f| %>
-              <%= f.submit "Unenroll", class: "btn btn-danger" %>
-            <% end %>
           </div>
         </div>
       </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,16 +26,13 @@ Rails.application.routes.draw do
 
   resources :enrolments do
     resources :reviews, only: [:new, :create]
+    delete :remove, on: :member
   end
+
 
   get 'users', to: 'users#index'
 
   get 'dashboard', to: 'pages#dashboard'
 
   resources :reviews, only: [:new, :create, :edit, :update, :destroy]
-
-  delete "enrol/:id", to: "enrolments#destroy", as: :enrol
-  delete 'enrolments/:id/remove', to: 'enrolments#remove_enrolment', as: 'remove_enrolment'
-
-
 end


### PR DESCRIPTION
Fix foreign key violation when deleting enrolment with associated reviews

When a user tried to unenroll from a course that had reviews, the server raised a
foreign key violation error because the enrolment record couldn't be deleted
while there were reviews referencing it. To fix this, we added the dependent
destroy option to the enrolment has_many reviews association, which causes the
associated reviews to be deleted when the enrolment is destroyed.

Add enroll button and functionality

- Add enroll button to course show page
- Implement enroll action in EnrolmentsController#create
- Add before_action to set course in EnrolmentsController
- Implement enrolled_in? method in User model
- Implement authorization for enroll and unenroll actions in EnrolmentsController
Commit for adding unenroll button and functionality:
